### PR TITLE
Bug fix: use iloc on pandas series

### DIFF
--- a/mock_request/requests.py
+++ b/mock_request/requests.py
@@ -72,7 +72,7 @@ class MockRequests():
             if len(path) != 1:
                 raise ValueError('The destination of this request is not unique.')
             else:
-                path = path[0]
+                path = path.iloc[0]
 
 
             # Load pickled response


### PR DESCRIPTION
`path` is a pandas series. `path[0]` is intended to access first item in series, but actually accesses index. Syntax error when there is no index 0, semantic error if index 0 is not first item. Use `path.iloc[0]` instead.